### PR TITLE
Add HuC1 mapper compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .vscode/
+build/

--- a/src/CartridgeGBHuC1.cpp
+++ b/src/CartridgeGBHuC1.cpp
@@ -73,7 +73,7 @@ uint32_t CartridgeGBHuC1::readRAM(void *buf_, uint32_t size, uint32_t offset){
   }
 
   // Disable RAM
-  gb_write_byte(0x0000, 0x00);
+  gb_write_byte(0x0000, 0x0E);
 
   // Reset bank selection
   gb_write_byte(0x4000, 0x0);
@@ -114,7 +114,7 @@ uint32_t CartridgeGBHuC1::writeRAM(const void *buf_, uint32_t size, uint32_t off
   }
 
   // Disable RAM
-  gb_write_byte(0x0000, 0x00);
+  gb_write_byte(0x0000, 0x0E);
 
   // Reset bank selection
   gb_write_byte(0x4000, 0x0);


### PR DESCRIPTION
The boilerplate code was mostly correct, except for the RAM disable command, which needed `0x0E`. Any other value will keep the RAM content in `$A000–BFFF`, which doesn't protect the RAM from corruption during power down or cartridge removal.